### PR TITLE
Wider support and more convenience

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,18 +1,14 @@
 #!/bin/bash
 run() {
-	printf "\033[32m+ \033[34m%s\033[0m\n" "$*"
+	printf "RUN: %s\n" "$*"
 	if ! "$@"; then
-		printf "\033[1;31mCommand returned an error. Abort.\n" 1>&2
+		printf "ERR\n" 1>&2
 		exit 1
 	fi
 }
 
-msg() {
-	printf "\033[1;36m%s\033[0m\n" "$@"
-}
-
 installer() {
-	msg "Installing files to system..."
+	echo "Installing files to system..."
 	run mkdir -p "$PREFIX/bin"
 	run cp -f "$BASE/tit" "$PREFIX/bin/tit"
 	run chmod +x "$PREFIX/bin/tit"
@@ -20,16 +16,16 @@ installer() {
 	run cp -f "$BASE/tit-completion.bash" "$PREFIX/etc/bash_completion.d/tit-completion.bash"
 	run mkdir -p "$PREFIX/share/doc/tit"
 	run cp -f "$BASE/README.md" "$PREFIX/share/doc/tit/README.md"
-	msg "Done. Run 'tit --help' to start using Termux-in-Termux."
+	echo "Done. Run 'tit --help' to start using Termux-in-Termux."
 }
 
 uninstaller() {
-	msg "Reverting changes to system..."
+	echo "Reverting changes to system..."
 	run rm -rf "$PREFIX/bin/tit"
 	run rm -rf "$PREFIX/etc/bash_completion.d/tit-completion.bash"
 	run rm -rf "$PREFIX/share/doc/tit/README.md"
 	run rm -rf "$HOME"/termux{,-pacman}-fs{,32}
-	msg "Done."
+	echo "Done."
 }
 
 # shellcheck disable=SC2155
@@ -43,6 +39,6 @@ case "$1" in
 		uninstaller
 		;;
 	*)
-		msg "Usage: $0 [install | uninstall]"
+		echo "Usage: $0 [install | uninstall]"
 		;;
 esac

--- a/tit
+++ b/tit
@@ -8,7 +8,7 @@ TERMUX_32_BIT=false
 TERMUX_PACMAN=false
 
 info() {
-	printf "\033[36m[!] %b\033[0m\n" "$*"
+	printf "RUN: %b\n" "$*"
 }
 
 error() {
@@ -17,7 +17,7 @@ error() {
 		EXIT=false
 		shift
 	fi
-	printf "\033[1;31m[x] %b\033[0m\n" "$*" 1>&2
+	printf "ERR: %b\n" "$*" 1>&2
 	if [ "$EXIT" = true ]; then
 		exit 1
 	fi
@@ -25,7 +25,7 @@ error() {
 }
 
 ok() {
-	printf "\033[32m[✓] %b\033[0m\n" "$*"
+	printf "OK:  %b\n" "$*"
 }
 
 run() {
@@ -46,43 +46,6 @@ run() {
 unset cleanup
 trap "error -n \"Received SIGINT\"; if [ \"\$(type -t cleanup)\" = \"function\" ]; then run \"Cleaning up\" cleanup; fi; exit 1" INT
 
-similar() {
-	if ! command -v python3 > /dev/null; then
-		printf "\n"
-		return 1
-	fi
-	python3 - <<- EOM
-	from functools import lru_cache
-
-	def lev_dist(s):
-	    @lru_cache(None)
-	    def min_dist(x, y):
-	        if x == len(s) or y == len(u):
-	            return len(s) - x + len(u) - y
-
-	        if s[x] == u[y]:
-	            return min_dist(x + 1, y + 1)
-
-	        return 1 + min(
-	            min_dist(x, y + 1),
-	            min_dist(x + 1, y),
-	            min_dist(x + 1, y + 1)
-	        )
-
-	    return min_dist(0, 0)
-
-	u="$1"
-	if len(u) == 0:
-	    print("")
-	else:
-	    m = min(map(lambda cmd: (cmd, lev_dist(cmd)), ("install", "login", "remove", "list", "backup", "restore", "help")), key=lambda t: t[1])
-	    if m[1] <= 3:
-	        print(f"    \033[1;31mDo you mean: '{m[0]}'?\033[0m\n")
-	    else:
-	        print("")
-	EOM
-}
-
 usage() {
 	local EXITCODE=1
 	# shellcheck disable=SC2155
@@ -95,25 +58,20 @@ usage() {
 		error -n "$@" 1>&2
 		printf "\n" 1>&2
 	fi
-	printf "%b\033[0m\n" "\033[1;33mTermux-in-Termux (by marquis-ng)"\
-		"\033[2mAn isolated environment of Termux inside Termux."\
-		"\033[2mGitHub: https://github.com/marquis-ng/termux-in-termux\n"\
-		"\033[1;33mUsage:"\
-		"  \033[32m$PROGNAME \033[22;35mCOMMAND \033[36m{ARGS[]}"\
-		"  \033[32m$PROGNAME \033[22;35m[-h,--help,help]\n"\
-		"\033[1;33mCommands:"\
-		"  \033[35minstall \033[36m[--32-bit | -p,--pacman | --reset]"\
-		"      \033[34mInstall the sandbox."\
-		"  \033[35mlogin \033[36m[--32-bit | -p,--pacman | -b,--bind {DIR | FILE} |\n          -w,--workdir {DIR}] [-- {CMD[]}]"\
-		"      \033[34mLogin the sandbox."\
-		"  \033[35mremove \033[36m[--32-bit | -p,--pacman | -y,--yes]"\
-		"      \033[34mRemove the sandbox."\
-		"  \033[35mlist \033[36m[-i,--installed | -s,--size]"\
-		"      \033[34mShow disk usage for each sandbox."\
-		"  \033[35mbackup \033[36m[--32-bit | -p,--pacman | -f,--force] -o,--output {FILE}"\
-		"      \033[34mBackup the sandbox."\
-		"  \033[35mrestore \033[36m[-y,--yes] -a,--archive {FILE}"\
-		"      \033[34mRestore a backup made by the program." 1>&2
+	printf "%b\n" "Termux-in-Termux-Minimal"\
+		"Commands:"\
+		"  install [--32-bit | -p,--pacman | --reset]"\
+		"      Install sandbox"\
+		"  login [--32-bit | -p,--pacman | -b,--bind {DIR | FILE} | -w,--workdir DIR] [-- CMD]"\
+		"      Login sandbox"\
+		"  remove [--32-bit | -p,--pacman | -y,--yes]"\
+		"      Remove sandbox"\
+		"  list [-i,--installed | -s,--size]"\
+		"      List sandboxes"\
+		"  backup [--32-bit | -p,--pacman | -f,--force] -o,--output FILE"\
+		"      Backup sandbox"\
+		"  restore [-y,--yes] -a,--archive FILE"\
+		"      Restore backup of sandbox" 1>&2
 	exit "$EXITCODE"
 }
 
@@ -336,10 +294,10 @@ tit_install_busybox() {
 			run "Remove BusyBox binary" rm -rf "$BUSYBOX"
 		fi
 		mkdir -p "$(dirname "$BUSYBOX")"
-		run "Download new BusyBox binary" wget "https://github.com/marquis-ng/termux-in-termux/raw/main/busybox/busybox-$BOOTSTRAP_ARCH" -q --show-progress -O "$BUSYBOX"
+		run "Download new BusyBox binary" wget "https://github.com/tovicheung/termux-in-termux=minimal/raw/main/busybox/busybox-$BOOTSTRAP_ARCH" -q --show-progress -O "$BUSYBOX"
 	fi
 
-	if ! run -n "Verify SHA256 of BusyBox binary" [ "$(wget -qO- https://raw.githubusercontent.com/marquis-ng/termux-in-termux/main/busybox/busybox.sha256sum | awk "\$2 == \"busybox-$BOOTSTRAP_ARCH\" {printf(\$1)}")" =  "$(sha256sum "$BUSYBOX" | awk "{printf(\$1)}")" ]; then
+	if ! run -n "Verify SHA256 of BusyBox binary" [ "$(wget -qO- https://raw.githubusercontent.com/tovicheung/termux-in-termux-minimal/main/busybox/busybox.sha256sum | awk "\$2 == \"busybox-$BOOTSTRAP_ARCH\" {printf(\$1)}")" =  "$(sha256sum "$BUSYBOX" | awk "{printf(\$1)}")" ]; then
 		if run "Remove corrupted BusyBox bianry" rm -f "$BUSYBOX"; then
 			info "Restart script"
 			exec "$(realpath -- "$0")" "${ARGS[@]}"
@@ -534,12 +492,12 @@ tit_list() {
 		fi
 		if tit_check_installed; then
 			if [ "$SHOW_SIZE" = true ]; then
-				printf "\033[32m%s\033[0m \033[34m%s\033[0m\n" "$(basename "$TERMUX_ROOTFS_PATH")" "$(du -sh "$TERMUX_ROOTFS_PATH" 2>/dev/null | awk "{printf(\$1)}")"
+				printf "%s %s\n" "$(basename "$TERMUX_ROOTFS_PATH")" "$(du -sh "$TERMUX_ROOTFS_PATH" 2>/dev/null | awk "{printf(\$1)}")"
 			else
-				printf "\033[32m%s\033[0m\n" "$(basename "$TERMUX_ROOTFS_PATH")"
+				printf "%s\n" "$(basename "$TERMUX_ROOTFS_PATH")"
 			fi
 		elif [ "$ONLY_INSTALLED" = false ]; then
-			printf "\033[31m%s\033[0m\n" "$(basename "$TERMUX_ROOTFS_PATH")"
+			printf "%s\n" "$(basename "$TERMUX_ROOTFS_PATH")"
 		fi
 	done
 }
@@ -672,7 +630,7 @@ if [ "$#" = 0 ]; then
 	usage "No command provided"
 fi
 case "$1" in
-	install)
+	install|i)
 		shift
 		tit_install "$@"
 		;;
@@ -680,7 +638,7 @@ case "$1" in
 		shift
 		tit_login "$@"
 		;;
-	remove)
+	remove|rm)
 		shift
 		tit_remove "$@"
 		;;
@@ -701,7 +659,6 @@ case "$1" in
 		;;
 	*)
 		error -n "Unrecognized command: '$1'"
-		similar "$1" 1>&2
 		usage
 		;;
 esac


### PR DESCRIPTION
- removed unicode character "✓" for wider support (different fonts?)
- removed similarity check (unnecessary as there are only 7 commands)
- added simple alias (rm -> remove, i -> install)
- removed use of ANSI color codes for wider support (dumb terminals)